### PR TITLE
Update scribe-factory.R

### DIFF
--- a/manipulation/scribe-factory.R
+++ b/manipulation/scribe-factory.R
@@ -256,7 +256,7 @@ directories %>%
 ds_table %>%
   dplyr::select(d, path_output) %>%
   dplyr::filter(!(fs:path_ext(path_output) %in% c("sas7bdat", "sav"))) %>%
-  purrr::pwalk(.f = ~readr::write_csv(.x, .y))
+  purrr::pwalk(.f = ~readr::write_csv(.x, .y, na=''))
 
 ds_table %>%
   dplyr::select(d, path_output) %>%


### PR DESCRIPTION
@wibeasley as a default, is there a reason not to default this to writing NAs as blank cells rather than 'NA'? See proposed change, and reject if ya wanna.